### PR TITLE
Change Raven filter's secure_headers config to be case insensitive

### DIFF
--- a/lib/blouson/raven_parameter_filter_processor.rb
+++ b/lib/blouson/raven_parameter_filter_processor.rb
@@ -3,7 +3,7 @@ module Blouson
     def self.create(filters, header_filters)
       Class.new(Raven::Processor) do
         @filters = filters
-        @header_filters = header_filters
+        @header_filters = header_filters.map(&:downcase)
 
         def self.filters
           @filters

--- a/spec/blouson/raven_parameter_filter_processer_spec.rb
+++ b/spec/blouson/raven_parameter_filter_processer_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'raven'
+require 'blouson/raven_parameter_filter_processor'
+
+RSpec.describe 'Blouson::RavenParameterFilterProcessor' do
+  describe 'process_request_headers' do
+    let(:filter_processor_class) {
+      Blouson::RavenParameterFilterProcessor.create(
+        [],
+        %w(Really-Sensitive-Header-That-Needs-To-Be-Filtered)
+      )
+    }
+
+    let(:value) {
+      {
+        request: {
+          headers: {
+            'Really-Sensitive-Header-That-Needs-To-Be-Filtered' => 'important_token',
+            'Insensitive-Header' => 'foo'
+          }
+        }
+      }
+    }
+
+    it 'filters headers in header_filters' do
+      processed_value = filter_processor_class.new.process(value)
+      expect(processed_value[:request][:headers]['Really-Sensitive-Header-That-Needs-To-Be-Filtered']).to eq('FILTERED')
+    end
+
+    it 'won\'t filter headers not in header_filters' do
+      processed_value = filter_processor_class.new.process(value)
+      expect(processed_value[:request][:headers]['Insensitive-Header']).to eq('foo')
+    end
+  end
+end


### PR DESCRIPTION
This PR allows HTTP header names passed to RavenParameterFilterProcessor#create to be capitalized.

When RavenParameterFilterProcessor checks if a HTTP header is included in `@header_filters`, it downcases **ONLY** the request's header:
https://github.com/cookpad/blouson/blob/b9add2879774735dcdc80c9f59050310871c2b22/lib/blouson/raven_parameter_filter_processor.rb#L60

This means that if the user capitalizes a header name in `secure_headers`, it just slips through the filter, and the content goes out to Sentry. This is pretty much confusing.

Wouldn't it be nicer to just downcase `header_filters` at the library side?