### PR TITLE
ActiveRecord::StatementInvalid can be created with no arguments

### DIFF
--- a/lib/blouson/sensitive_query_filter.rb
+++ b/lib/blouson/sensitive_query_filter.rb
@@ -15,7 +15,7 @@ module Blouson
     end
 
     module StatementInvalidErrorFilter
-      def initialize(message, original_exception = nil)
+      def initialize(message = nil, original_exception = nil)
         if SensitiveQueryFilter.contain_sensitive_query?(message)
           message = SensitiveQueryFilter.filter_sensitive_words(message)
           if defined?(Mysql2::Error)

--- a/spec/blouson/sensitive_query_filter_spec.rb
+++ b/spec/blouson/sensitive_query_filter_spec.rb
@@ -156,5 +156,23 @@ RSpec.describe Blouson::SensitiveQueryFilter do
         end
       end
     end
+
+    context 'on no database error' do
+      before do
+        dummy_nodb_error = Class.new(ActiveRecord::StatementInvalid)
+        stub_const('ActiveRecord::NoDatabaseError', dummy_nodb_error)
+      end
+
+      it 'raises ActiveRecord::NoDatabaseError' do
+        error = nil
+        begin
+          raise ActiveRecord::NoDatabaseError
+        rescue => e
+          error = e
+        end
+        expect(error.to_s).to eq('ActiveRecord::NoDatabaseError')
+        expect(error.to_s).not_to include('[FILTERED]')
+      end
+    end
   end
 end


### PR DESCRIPTION
# Issue

`AR::NoDatabaseError` is a descendant of `AR::StatementInvalid`, which takes no arguments to initialize.
When `AR::NoDatabaseError` with `blouson` enabled,  `StatementInvalidErrorFilter#initialize` complains about the mismatch of the number of arguments.

```
expected: "ActiveRecord::NoDatabaseError"
got: "wrong number of arguments (given 0, expected 1..2)"
```

## Related

After https://github.com/rails/rails/pull/21511, all kinds of `ActiveRecordError` can be created without arguments. 