### PR TITLE
Do not set hook when active record is not defined

### DIFF
--- a/lib/blouson/engine.rb
+++ b/lib/blouson/engine.rb
@@ -6,7 +6,8 @@ module Blouson
 
     # We have to prevent logging sensitive data in SQL if production mode and logger level is debug
     initializer 'blouson.load_helpers' do |app|
-      if !Rails.env.development? && Rails.logger.level == Logger::DEBUG
+      # Don't need to set hook when active_record is not required
+      if !Rails.env.development? && Rails.logger.level == Logger::DEBUG && defined?(ActiveRecord)
         ActiveSupport.on_load(:action_controller) do
           around_action Blouson::SensitiveParamsSilencer
         end


### PR DESCRIPTION
I want to use this gem on rails application without database,
but It will fail when request come since Active Record is not required.

Most of cases use Active Record, so I'm not sure this patch is acceptable or not 😂 
How do you think? @cookpad/infra @hokaccha 