### PR TITLE
Fix inconsistent definitions in Appraisals

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,13 +1,3 @@
-appraise 'rails-4.0' do
-  gem 'rails', '~> 4.0.0'
-  gem 'mysql2', '~> 0.3.10'
-end
-
-appraise 'rails-4.1' do
-  gem 'rails', '~> 4.1.0'
-  gem 'mysql2', '~> 0.3.13'
-end
-
 appraise 'rails-4.2' do
   gem 'rails', '~> 4.2.0'
 end
@@ -18,6 +8,10 @@ end
 
 appraise 'rails-5.1' do
   gem 'rails', '~> 5.1.0'
+end
+
+appraise 'rails-5.2' do
+  gem 'rails', '~> 5.2.0'
 end
 
 # vim: set ft=ruby:


### PR DESCRIPTION
ref: https://github.com/cookpad/blouson/commit/3c11787922cbf1faf41b1ef303dd450a4f516fc3

While Rails 4.0 and 4.1 were dropped from testing target at the commit above, It seems that these changes are not applied to Appraisals.

This PR fixes the inconsistency.

Please take a look 👀 @cookpad/infra @hokaccha 