### PR TITLE
Change to use ActiveSupport::LoggerSilence

### DIFF
--- a/lib/blouson/sensitive_table_query_log_silencer.rb
+++ b/lib/blouson/sensitive_table_query_log_silencer.rb
@@ -5,12 +5,9 @@ module Blouson
         return super(sql, name)
       end
 
-      begin
-        ActiveRecord::Base.logger.level = Logger::INFO
+      ActiveRecord::Base.logger.silence(Logger::INFO) do
         Rails.logger.info "  [Blouson::SensitiveTableQueryLogSilencer] SQL Log is skipped for sensitive table"
         super(sql, name)
-      ensure
-        ActiveRecord::Base.logger.level = Logger::DEBUG
       end
     end
   end


### PR DESCRIPTION
Direct assignment to `ActiveRecord::Base.logger.level` is not thread-safe.

@cookpad/infra @hokaccha @riseshia  Please review.
