### PR TITLE
Fix cookies not being filtered when Raven::Rack is used

### DIFF
--- a/lib/blouson/raven_parameter_filter_processor.rb
+++ b/lib/blouson/raven_parameter_filter_processor.rb
@@ -71,6 +71,10 @@ module Blouson
         end
 
         def process_cookie(value)
+          if (cookies = value.dig(:request, :cookies))
+            value[:request][:cookies] = @parameter_filter.filter(cookies)
+          end
+
           if value[:request] && value[:request][:headers] && value[:request][:headers]['Cookie']
             cookies  = Hash[value[:request][:headers]['Cookie'].split('; ').map { |pair| pair.split('=', 2) }]
             filtered = @parameter_filter.filter(cookies)


### PR DESCRIPTION
When Raven::Rack is used, a processor receives cookies not in `data[:request][:headers]['Cookie']` but in `data[:request][:cookies]`.

https://github.com/getsentry/sentry-ruby/blob/3.1.1/lib/raven/integrations/rack.rb#L79
https://github.com/getsentry/sentry-ruby/blob/3.1.1/lib/raven/integrations/rack.rb#L124