### PR TITLE
Fix ArgumentError on activerecord 7.0

### DIFF
--- a/lib/blouson/sensitive_table_query_log_silencer.rb
+++ b/lib/blouson/sensitive_table_query_log_silencer.rb
@@ -1,13 +1,13 @@
 module Blouson
   class SensitiveTableQueryLogSilencer < Arproxy::Base
-    def execute(sql, name=nil)
+    def execute(sql, name=nil, **kwargs)
       if Rails.logger.level != Logger::DEBUG || !(Blouson::SENSITIVE_TABLE_REGEXP === sql)
-        return super(sql, name)
+        return super(sql, name, **kwargs)
       end
 
       ActiveRecord::Base.logger.silence(Logger::INFO) do
         Rails.logger.info "  [Blouson::SensitiveTableQueryLogSilencer] SQL Log is skipped for sensitive table"
-        super(sql, name)
+        super(sql, name, **kwargs)
       end
     end
   end


### PR DESCRIPTION
The #execute method may have keyword-arguments, particular at MySQL adapter since activerecord 7.0.0.
See also: https://github.com/rails/rails/commit/7fc174aadaefc2c0a8a6b7c8a7599dd9ca04811f

ref. https://github.com/cookpad/arproxy/pull/21