### PR TITLE
Add optional support to setnry-ruby gem by implemening SentryParameterFilter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,28 @@ end
 Arproxy.enable!
 ```
 
+### SentryParameterFilter
+Blouson provides an [sentry-ruby](https://github.com/getsentry/sentry-ruby) filter to conceal sensitive data from query string, request body, request headers and cookie values.
+
+```ruby
+require 'sentry-ruby'
+require 'blouson/sentry_parameter_filter'
+
+Sentry.init do |config|
+  # Enable `send_default_pii` to send the filtered sensitive information.
+  config.send_default_pii = true
+
+  filter_pattern = Rails.application.config.filter_parameters
+  secure_headers = %w(secret_token)
+  filter = Blouson::SentryParameterFilter.new(filter_pattern, secure_headers)
+
+  config.before_send = lambda do |event, _hint|
+    filter.process(event.to_hash)
+  end
+end
+
+```
+
 ### RavenParameterFilterProcessor
 Blouson provides an [Raven-Ruby](https://github.com/getsentry/raven-ruby) processor to conceal sensitive data from query string, request body, request headers and cookie values.
 
@@ -80,6 +102,7 @@ Raven.configure do |config|
   ...
 end
 ```
+
 
 ### SensitiveMailLogFilter
 ActionMailer outputs email address, all headers, and body text to the log when sending email.

--- a/blouson.gemspec
+++ b/blouson.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'rails', '>= 4.0.0'
-  spec.add_dependency 'sentry-raven'
 
   spec.add_development_dependency 'arproxy'
   spec.add_development_dependency 'mysql2'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'sentry-raven'
   spec.add_development_dependency 'sentry-ruby'
 
   spec.add_development_dependency 'appraisal'

--- a/blouson.gemspec
+++ b/blouson.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'arproxy'
   spec.add_development_dependency 'mysql2'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'sentry-ruby'
 
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency "bundler", ">= 1.14"

--- a/lib/blouson/sentry_parameter_filter.rb
+++ b/lib/blouson/sentry_parameter_filter.rb
@@ -1,0 +1,76 @@
+module Blouson
+  class SentryParameterFilter
+    def initialize(filters, header_filters = [])
+      # ActionDispatch::Http::ParameterFilter is deprecated and will be removed from Rails 6.1.
+      parameter_filter_klass = if defined?(ActiveSupport::ParameterFilter)
+                                 ActiveSupport::ParameterFilter
+                               else
+                                 ActionDispatch::Http::ParameterFilter
+                               end
+      @parameter_filter = parameter_filter_klass.new(filters)
+      @header_filters = header_filters.map(&:downcase)
+    end
+
+    def process(event)
+      process_query_string(event)
+      process_request_body(event)
+      process_request_header(event)
+      process_cookie(event)
+    ensure
+      return event
+    end
+
+    private
+
+    def process_request_body(event)
+      if event[:request] && event[:request][:data].present?
+        data = event[:request][:data]
+        if data.is_a?(String)
+          # Maybe JSON request
+          begin
+            data = JSON.parse(data)
+            event[:request][:data] = JSON.dump(@parameter_filter.filter(data))
+          rescue JSON::ParserError => e
+            # Record parser error to extra field
+            event[:extra]['BlousonError'] = e.message
+          end
+        else
+          event[:request][:data] = @parameter_filter.filter(data)
+        end
+      end
+    end
+
+    def process_query_string(event)
+      if event[:request] && event[:request][:query_string].present?
+        query    = Rack::Utils.parse_query(event[:request][:query_string])
+        filtered = @parameter_filter.filter(query)
+
+        event[:request][:query_string] = Rack::Utils.build_query(filtered)
+      end
+    end
+
+    def process_request_header(event)
+      if event[:request] && event[:request][:headers]
+        headers = event[:request][:headers]
+        headers.each_key do |k|
+          if @header_filters.include?(k.downcase)
+            headers[k] = 'FILTERED'
+          end
+        end
+      end
+    end
+
+    def process_cookie(event)
+      if (cookies = event.dig(:request, :cookies))
+        event[:request][:cookies] = @parameter_filter.filter(cookies)
+      end
+
+      if event[:request] && event[:request][:headers] && event[:request][:headers]['Cookie']
+        cookies  = Hash[event[:request][:headers]['Cookie'].split('; ').map { |pair| pair.split('=', 2) }]
+        filtered = @parameter_filter.filter(cookies)
+
+        event[:request][:headers]['Cookie'] = filtered.map { |pair| pair.join('=') }.join('; ')
+      end
+    end
+  end
+end

--- a/spec/blouson/sentry_parameter_filter_spec.rb
+++ b/spec/blouson/sentry_parameter_filter_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+require 'sentry-ruby'
+require 'blouson/sentry_parameter_filter'
+
+RSpec.describe Blouson::SentryParameterFilter do
+  let(:filters) { ['sensitive-data'] }
+  let(:header_filters) { %w(Really-Sensitive-Header-That-Needs-To-Be-Filtered) }
+  let(:filter_class) { described_class.new(filters, header_filters) }
+
+  let(:event) do
+    {
+      request: {
+        headers: {
+          'Really-Sensitive-Header-That-Needs-To-Be-Filtered' => 'important_token',
+          'Insensitive-Header' => 'foo',
+          'Cookie' => 'sensitive-data=secret-value; foo=non-secret-value'
+        },
+        cookies: {
+          'sensitive-data' => 'secret-value',
+          'foo' => 'non-secret-value'
+        },
+        data: "{\"sensitive-data\":\"secret-value\",\"normal-data\": {\"some-sensitive-data\":\"secret-value\"}}",
+        query_string: 'sensitive-data=secret-value&normal-data=non-secret-value',
+      }
+    }
+  end
+
+  describe 'process_request_body' do
+    it 'filters request body in the filters' do
+      processed_event = filter_class.process(event)
+      data = JSON.parse(processed_event[:request][:data])
+      expect(data['sensitive-data']).to eq('[FILTERED]')
+    end
+
+    it 'do not filters request body not in the filters but nested value is filtered' do
+      processed_event = filter_class.process(event)
+      data = JSON.parse(processed_event[:request][:data])
+      expect(data['normal-data']).to eq({ 'some-sensitive-data' => '[FILTERED]' })
+    end
+  end
+
+  describe 'process_query_string' do
+    it 'filters query string in the filters' do
+      processed_event = filter_class.process(event)
+      query = Rack::Utils.parse_query(processed_event[:request][:query_string])
+      expect(query['sensitive-data']).to eq('[FILTERED]')
+    end
+
+    it 'do not filters query string not in the filters' do
+      processed_event = filter_class.process(event)
+      query = Rack::Utils.parse_query(processed_event[:request][:query_string])
+      expect(query['normal-data']).to eq('non-secret-value')
+    end
+  end
+
+  describe 'process_request_header' do
+    it 'filters headers in the header_filters' do
+      processed_event = filter_class.process(event)
+      expect(processed_event[:request][:headers]['Really-Sensitive-Header-That-Needs-To-Be-Filtered']).to eq('FILTERED')
+    end
+
+    it 'do not filter headers not in header_filters' do
+      processed_event = filter_class.process(event)
+      expect(processed_event[:request][:headers]['Insensitive-Header']).to eq('foo')
+    end
+  end
+
+  describe 'process_cookie' do
+    it 'filters values in cookie in filters' do
+      processed_event = filter_class.process(event)
+      expect(processed_event[:request][:cookies]['sensitive-data']).to eq('[FILTERED]')
+      expect(processed_event[:request][:cookies]['foo']).to eq('non-secret-value')
+      expect(processed_event[:request][:headers]['Cookie']).to eq('sensitive-data=[FILTERED]; foo=non-secret-value')
+    end
+  end
+end


### PR DESCRIPTION
I would introduce a new filter Blouson::SentryParameterFilter to support `sentry-ruby` gem which is the successor of `sentry-raven` gem. It is based on Blouson::RavenParameterFilterProcessor, but `sentry-ruby` gem does not keep the [processor engine](https://docs.sentry.io/platforms/ruby/migration/#removed-processors). So, `Blouson::SentryParameterFilter` is implemented as a plain ruby class and is used as follows.

```Gemfile
gem 'sentry-ruby'
gem 'sentry-rails'
gem 'blouson'
```

```sentry.rb
# frozen_string_literal: true

require 'blouson/sentry_parameter_filter'

Sentry.init do |config|
  config.dsn = ENV['SENTRY_DSN']
  config.send_default_pii = true
  filter = Blouson::SentryParameterFilter.new(Rails.application.config.filter_parameters, [])
  config.before_send = lambda do |event, hint|
    filter.process(event.to_hash)
  end
end
```

cf. https://docs.sentry.io/platforms/ruby/guides/rails/data-management/sensitive-data/#scrubbing-data