### PR TITLE
gitignore lock files for appraisal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /.yardoc
 /Gemfile.lock
+/gemfiles/*.gemfile.lock
 /_yardoc/
 /coverage/
 /doc/
@@ -10,4 +11,3 @@
 
 # rspec failure tracking
 .rspec_status
-*.iml


### PR DESCRIPTION
Appraisal generates several lockfiles when we run it on our local machine.

```console
% ls gemfiles 
rails_6.0.gemfile      rails_6.1.gemfile      rails_7.0.gemfile      rails_7.1.gemfile
rails_6.0.gemfile.lock rails_6.1.gemfile.lock rails_7.0.gemfile.lock rails_7.1.gemfile.lock
```
